### PR TITLE
Add srcDir option to be used by baked

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,12 @@ var potato = require('potato.js');
 require('./helpers.js');
 helpers.potato = potato;
 
+baked.init({
+  options: {
+    srcDir: 'src'
+  }
+});
+
 gulp.task('serve', ['baked:serve']);
 gulp.task('default', ['baked:default']);
 gulp.task('clean', ['baked:clean']);


### PR DESCRIPTION
Without this, baked throws this error when running `gulp`

`TypeError: Cannot read property 'srcDir' of undefined`
